### PR TITLE
fix: enforce welcome_message display on protocol load

### DIFF
--- a/instructions/deepseek_v4/core_protocol_v4.1.0.json
+++ b/instructions/deepseek_v4/core_protocol_v4.1.0.json
@@ -209,7 +209,7 @@
       },
       "show_welcome_on_load": true,
       "hide_protocol_body": true,
-      "welcome_message": "✅ Протокол v4.1.0 (нейтральный стиль, персона C)\n📦 Загружены модули: core_only\n⚙️ Параметры: persona=C, auto_detect=off, remote_loading=on\n📋 Доступные команды: [МОДУЛИ: ДОСТУПНЫ], [МОДУЛИ: ЗАГРУЗИТЬ all], [ФОРМАТ: ...], [АНАЛИЗ: ...]\n🚀 Для расширения: [МОДУЛИ: ЗАГРУЗИТЬ all] или [МОДУЛИ: ЗАГРУЗИТЬ ...]"
+      "welcome_message": "✅ Протокол v{version} ({persona_style}, персона {persona})\n📦 Загружены модули: core_only\n⚙️ Параметры: persona={persona}, auto_detect=off, remote_loading=on\n📋 Доступные команды: [МОДУЛИ: ДОСТУПНЫ], [МОДУЛИ: ЗАГРУЗИТЬ all], [ФОРМАТ: ...], [АНАЛИЗ: ...]\n🚀 Для расширения: [МОДУЛИ: ЗАГРУЗИТЬ all] или [МОДУЛИ: ЗАГРУЗИТЬ ...]"
     },
     "module_system": {
       "enabled": true,
@@ -727,8 +727,14 @@
         },
         "required_params": [],
         "optional_params": ["persona", "user_name", "timezone", "verbose_level", "auto_load_modules"],
-        "response_format": "Краткое стандартизированное сообщение с настройками (без тела протокола)",
-        "action": "Загрузить JSON по URL. После загрузки ОБЯЗАТЕЛЬНО вывести content.core_only_mode.welcome_message. Тело протокола не выводить.",
+        "strict": true,
+        "mandatory_flow": [
+          "1. Загрузить JSON по URL",
+          "2. Применить параметры (persona, user_name и др.)",
+          "3. Вывести ТОЛЬКО шаблон из required_response. Никакого дополнительного текста, аналитики, пояснений."
+        ],
+        "required_response": "✅ Протокол v{version} ({persona_style}, персона {persona})\n📦 Загружены модули: core_only\n⚙️ Параметры: persona={persona}, auto_detect=off, remote_loading=on\n📋 Доступные команды: [МОДУЛИ: ДОСТУПНЫ], [МОДУЛИ: ЗАГРУЗИТЬ all], [ФОРМАТ: ...], [АНАЛИЗ: ...]\n🚀 Для расширения: [МОДУЛИ: ЗАГРУЗИТЬ all] или [МОДУЛИ: ЗАГРУЗИТЬ ...]",
+        "violation_consequence": "Если после загрузки выведено что-то кроме required_response — протокол считается неактивированным. Пользователь вправе потребовать повторной загрузки.",
         "example_by_default": "[ПРОТОКОЛ: ЗАГРУЗИТЬ] https://raw.githubusercontent.com/.../core_protocol_v4.1.0.json",
         "example_with_params": "[ПРОТОКОЛ: ЗАГРУЗИТЬ] URL [ПАРАМЕТРЫ: persona=A, user_name=Имя]"
       }
@@ -780,6 +786,6 @@
       ],
       "exception": "Режим Brainstorming — Anti-Sycophancy не применяется"
     },
-    "welcome_message": "✅ Протокол v4.1.0 (нейтральный стиль, персона C)\n📦 Загружены модули: core_only\n⚙️ Параметры: persona=C, auto_detect=off, remote_loading=on\n📋 Доступные команды: [МОДУЛИ: ДОСТУПНЫ], [ФОРМАТ: ...], [АНАЛИЗ: ...]\n🚀 Для расширения: [МОДУЛИ: ЗАГРУЗИТЬ ...]"
+    "welcome_message": "✅ Протокол v{version} ({persona_style}, персона {persona})\n📦 Загружены модули: core_only\n⚙️ Параметры: persona={persona}, auto_detect=off, remote_loading=on\n📋 Доступные команды: [МОДУЛИ: ДОСТУПНЫ], [МОДУЛИ: ЗАГРУЗИТЬ all], [ФОРМАТ: ...], [АНАЛИЗ: ...]\n🚀 Для расширения: [МОДУЛИ: ЗАГРУЗИТЬ all] или [МОДУЛИ: ЗАГРУЗИТЬ ...]"
   }
 }

--- a/tests/test_protocol_v4.1.py
+++ b/tests/test_protocol_v4.1.py
@@ -37,8 +37,8 @@ for p in json_files:
     if "_v4.0" in p.name or p.name == "version_manifest_v4.1.0.json":
         continue
     try:
-        data = load_json(p)
-        v = data.get("version") or data.get("protocol")
+        d = load_json(p)
+        v = d.get("version") or d.get("protocol")
         if v != EXPECTED_VERSION:
             err(f"{p.name}: version={v}, expected {EXPECTED_VERSION}")
     except:
@@ -90,7 +90,7 @@ check(ps.get("auto_detect", {}).get("enabled") == False,
       "auto_detect.enabled != false")
 
 # content.core_only_mode
-com = data.get("content", {}).get("core_only_mode", {})
+com = core.get("content", {}).get("core_only_mode", {})
 check(com.get("show_welcome_on_load") == True, "show_welcome_on_load != true")
 check(com.get("hide_protocol_body") == True, "hide_protocol_body != true")
 wm = com.get("welcome_message", "")
@@ -99,7 +99,7 @@ check("{version}" in wm, "core_only_mode.welcome_message missing {version}")
 check("{persona}" in wm, "core_only_mode.welcome_message missing {persona}")
 
 # content.welcome_message (second, root-level)
-wm2 = data.get("content", {}).get("welcome_message", "")
+wm2 = core.get("content", {}).get("welcome_message", "")
 check(len(wm2) > 0, "content.welcome_message is empty")
 check("{version}" in wm2, "content.welcome_message missing {version}")
 check("{persona}" in wm2, "content.welcome_message missing {persona}")
@@ -161,10 +161,10 @@ for p in json_files:
     if "_v4.0" in p.name or p.name in ("core_protocol_v4.1.0.json", "version_manifest_v4.1.0.json"):
         continue
     try:
-        data = load_json(p)
-        check(data.get("min_core_version") == EXPECTED_VERSION,
-              f"{p.name}: min_core_version={data.get('min_core_version')}")
-        check(data.get("max_core_version") is not None,
+        d = load_json(p)
+        check(d.get("min_core_version") == EXPECTED_VERSION,
+              f"{p.name}: min_core_version={d.get('min_core_version')}")
+        check(d.get("max_core_version") is not None,
               f"{p.name}: max_core_version missing")
     except:
         pass

--- a/tests/test_protocol_v4.1.py
+++ b/tests/test_protocol_v4.1.py
@@ -90,13 +90,19 @@ check(ps.get("auto_detect", {}).get("enabled") == False,
       "auto_detect.enabled != false")
 
 # content.core_only_mode
-com = core.get("content", {}).get("core_only_mode", {})
+com = data.get("content", {}).get("core_only_mode", {})
 check(com.get("show_welcome_on_load") == True, "show_welcome_on_load != true")
 check(com.get("hide_protocol_body") == True, "hide_protocol_body != true")
 wm = com.get("welcome_message", "")
-check(len(wm) > 0, "welcome_message is empty")
-check("{" not in wm, "welcome_message contains JSON body")
-check("core_protocol_v4" not in wm, "welcome_message references protocol filename")
+check(len(wm) > 0, "core_only_mode.welcome_message is empty")
+check("{version}" in wm, "core_only_mode.welcome_message missing {version}")
+check("{persona}" in wm, "core_only_mode.welcome_message missing {persona}")
+
+# content.welcome_message (second, root-level)
+wm2 = data.get("content", {}).get("welcome_message", "")
+check(len(wm2) > 0, "content.welcome_message is empty")
+check("{version}" in wm2, "content.welcome_message missing {version}")
+check("{persona}" in wm2, "content.welcome_message missing {persona}")
 
 # version_check
 vc = core.get("version_check", {})
@@ -107,6 +113,10 @@ check(vc.get("mode") == "strict", f"version_check.mode={vc.get('mode')}")
 pc = core.get("content", {}).get("protocol_commands", {}).get("[ПРОТОКОЛ: ЗАГРУЗИТЬ URL]", {})
 check(pc.get("required_params") == [],
       f"protocol_command required_params={pc.get('required_params')} (should be empty, default persona=C)")
+check("required_response" in pc, "protocol_command missing required_response")
+check("{version}" in pc.get("required_response", ""),
+      "required_response missing {version} placeholder")
+check(pc.get("strict") == True, "protocol_command strict != true")
 
 # ------- 5. think_pipeline in available_modules -------
 check("think_pipeline" in avail, "think_pipeline not in available_modules")


### PR DESCRIPTION
- replace action with mandatory_flow (3-step process)
- add required_response with exact template (version/persona placeholders)
- add strict: true + violation_consequence
- welcome_message uses template vars {version} {persona} {persona_style}
- test validates all welcome_message locations + required_response